### PR TITLE
12.2.10 bufferoverflow

### DIFF
--- a/src/main/java/xtremweb/common/XWConfigurator.java
+++ b/src/main/java/xtremweb/common/XWConfigurator.java
@@ -537,7 +537,11 @@ public final class XWConfigurator extends Properties {
 	 * @see xtremweb.common.XWPropertyDefs#DBREQUESTLIMIT
 	 */
 	public int requestLimit() {
-		return getInt(XWPropertyDefs.DBREQUESTLIMIT);
+		int ret =  getInt(XWPropertyDefs.DBREQUESTLIMIT);
+		if (ret > 1000) {
+		    ret = 1000;
+		}
+		return ret;
 	}
 
 	/**

--- a/src/main/java/xtremweb/common/XWConfigurator.java
+++ b/src/main/java/xtremweb/common/XWConfigurator.java
@@ -538,8 +538,8 @@ public final class XWConfigurator extends Properties {
 	 */
 	public int requestLimit() {
 		int ret =  getInt(XWPropertyDefs.DBREQUESTLIMIT);
-		if (ret > 1000) {
-		    ret = 1000;
+		if (ret > XWTools.MAXDBREQUESTLIMIT) {
+		    ret = XWTools.MAXDBREQUESTLIMIT;
 		}
 		return ret;
 	}

--- a/src/main/java/xtremweb/common/XWPropertyDefs.java
+++ b/src/main/java/xtremweb/common/XWPropertyDefs.java
@@ -1228,7 +1228,7 @@ public enum XWPropertyDefs {
 		 */
 		@Override
 		public String defaultValue() {
-			return "1000";
+			return "" + XWTools.MAXDBREQUESTLIMIT;
 		}
 	},
 	/**

--- a/src/main/java/xtremweb/common/XWTools.java
+++ b/src/main/java/xtremweb/common/XWTools.java
@@ -121,6 +121,11 @@ public class XWTools {
 	 */
 	public static final int LONGFILESIZE = 250 * 1024;
 	/**
+	 * This is the maximum amount of rows returned by an SQL statement
+	 * @since 12.2.10
+	 */
+	public static final int MAXDBREQUESTLIMIT = 1000;
+	/**
 	 * This defines the maximum amount of messages in one single socket. The
 	 * server automatically closes socket when this limit is reached. This
 	 * ensures that client do not block a socket for too long since the server


### PR DESCRIPTION
DBMAXREQUEST must be lower to 1000; this is now forced